### PR TITLE
Implement dynamic list fading on scroll

### DIFF
--- a/src/components/layouts/Search.jsx
+++ b/src/components/layouts/Search.jsx
@@ -21,17 +21,20 @@ const Search = () => {
   );
   
   // State to track scroll position
-  const [isAtBottom, setIsAtBottom] = useState(false);
-  const [isAtTop, setIsAtTop] = useState(true); // we start at top
+  const [scrollState, setScrollState] = useState({ isAtTop: true, isAtBottom: false });
   const listRef = useRef(null);
 
   // Handle scroll events on the list
   const handleScroll = () => {
+    const scrollBuffer = 2; // account for rounding errors in browser
+
     if (listRef.current) {
       const { scrollTop, scrollHeight, clientHeight } = listRef.current;
 
-      setIsAtBottom(scrollTop + clientHeight >= scrollHeight);
-      setIsAtTop(scrollTop < 1);
+      setScrollState({
+        isAtTop: scrollTop < scrollBuffer,
+        isAtBottom: scrollTop + clientHeight >= scrollHeight - scrollBuffer,
+      });
     }
   };
 
@@ -44,8 +47,7 @@ const Search = () => {
     // Reset scroll position and state when search changes
     if (listRef.current) {
       listRef.current.scrollTop = 0;
-      setIsAtBottom(false);
-      setIsAtTop(true);
+      setScrollState({ isAtTop: true, isAtBottom: false });
     }
   };
 
@@ -80,8 +82,8 @@ const Search = () => {
         onScroll={handleScroll}
         className={clsx(
           'pl-6 pb-4 space-y-2 overflow-y-scroll text-white max-h-[300px] min-w-full',
-          isAtBottom && 'scroll-at-bottom',
-          !isAtTop && 'scroll-not-at-top'
+          scrollState.isAtBottom && 'scroll-at-bottom',
+          !scrollState.isAtTop && 'scroll-not-at-top'
         )}
       >
         {currMemberState.map((member, index) => {

--- a/src/components/layouts/Search.jsx
+++ b/src/components/layouts/Search.jsx
@@ -62,7 +62,7 @@ const Search = () => {
   };
 
   return (
-    <section className="grid max-w-[600px] min-w-[300px] min-h-full w-full space-y-4 pt-10">
+    <section className="grid max-w-[600px] min-w-[300px] h-full w-full space-y-4 pt-10">
       {/* search bar */}
       <div className="flex flex-row-reverse items-stretch font-mono text-lg text-secondary max-h-[44px] min-w-full">
         <Input

--- a/src/components/layouts/Search.jsx
+++ b/src/components/layouts/Search.jsx
@@ -86,26 +86,25 @@ const Search = () => {
           !scrollState.isAtTop && 'scroll-not-at-top'
         )}
       >
-        {currMemberState.map((member, index) => {
+        {currMemberState.map((member, _index) => {
           return (
             <div key={member.item.name} className="flex items-center">
               <span className="pr-8 text-yellow-500">&gt;</span>
-
               <li
                 onPointerOver={() => setMemberItem(member.item)}
                 key={member.item.name}
                 className="px-6 py-2.5 font-mono text-sm border-2 border-dotted border-stone-600 hover:bg-stone-800 hover:cursor-crosshair w-full truncate"
               >
-                <span className={member.item.legacy ? 'text-yellow-700' : ''}>
+                <span className={member.item.legacy && 'text-yellow-700'}>
                   {member.item.name}
                 </span>
-                &nbsp;|&nbsp;
+                {' | '}
                 <span className="text-yellow-500 underline transition duration-200 hover:text-yellow-600/40">
                   <a href={member.item.siteURL} target="_blank" rel="noreferrer">
                     {shortenURL(member.item.siteURL)}
                   </a>
                 </span>
-                &nbsp;{!member.item.legacy ? '|' : ''} {member.item.year}
+                &nbsp;{!member.item.legacy && '|'} {member.item.year}
               </li>
             </div>
           );

--- a/src/components/layouts/Search.jsx
+++ b/src/components/layouts/Search.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { Input } from '@/components/ui/input';
 import { members } from '@/pages/api/members';
 import Fuse from 'fuse.js';
@@ -18,12 +18,31 @@ const Search = () => {
   const [currMemberState, setCurrMemberState] = useState(
     members.map(member => ({ item: member }))
   );
+  
+  // State to track if we've scrolled to bottom
+  const [isAtBottom, setIsAtBottom] = useState(false);
+  const listRef = useRef(null);
+
+  // Handle scroll events on the list
+  const handleScroll = () => {
+    if (listRef.current) {
+      const { scrollTop, scrollHeight, clientHeight } = listRef.current;
+      // Check if we're near the bottom (within 20px)
+      const isNearBottom = scrollTop + clientHeight >= scrollHeight - 20;
+      setIsAtBottom(isNearBottom);
+    }
+  };
 
   const handleSearch = (e) => {
     if (!e.target.value) {
       setCurrMemberState(members.map(member => ({ item: member })));
     } else {
       setCurrMemberState(fuse.search(e.target.value));
+    }
+    // Reset scroll position and bottom state when search changes
+    if (listRef.current) {
+      listRef.current.scrollTop = 0;
+      setIsAtBottom(false);
     }
   };
 
@@ -53,7 +72,11 @@ const Search = () => {
       </div>
 
       {/* search results */}
-      <ul className="pl-6 pb-4 space-y-2 overflow-y-scroll text-white max-h-[300px] min-w-full">
+      <ul 
+        ref={listRef}
+        onScroll={handleScroll}
+        className={`pl-6 pb-4 space-y-2 overflow-y-scroll text-white max-h-[300px] min-w-full ${isAtBottom ? 'scroll-at-bottom' : ''}`}
+      >
         {currMemberState.map((member, index) => {
           return (
             <div key={member.item.name} className="flex items-center">

--- a/src/components/layouts/Search.jsx
+++ b/src/components/layouts/Search.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef } from 'react';
 import { Input } from '@/components/ui/input';
 import { members } from '@/pages/api/members';
 import Fuse from 'fuse.js';
 import { useMember } from '@/context/MemberContext';
+import clsx from 'clsx';
 
 const Search = () => {
   // Fuse.js for search
@@ -19,17 +20,18 @@ const Search = () => {
     members.map(member => ({ item: member }))
   );
   
-  // State to track if we've scrolled to bottom
+  // State to track scroll position
   const [isAtBottom, setIsAtBottom] = useState(false);
+  const [isAtTop, setIsAtTop] = useState(true); // we start at top
   const listRef = useRef(null);
 
   // Handle scroll events on the list
   const handleScroll = () => {
     if (listRef.current) {
       const { scrollTop, scrollHeight, clientHeight } = listRef.current;
-      // Check if we're near the bottom (within 20px)
-      const isNearBottom = scrollTop + clientHeight >= scrollHeight - 20;
-      setIsAtBottom(isNearBottom);
+
+      setIsAtBottom(scrollTop + clientHeight >= scrollHeight);
+      setIsAtTop(scrollTop < 1);
     }
   };
 
@@ -39,10 +41,11 @@ const Search = () => {
     } else {
       setCurrMemberState(fuse.search(e.target.value));
     }
-    // Reset scroll position and bottom state when search changes
+    // Reset scroll position and state when search changes
     if (listRef.current) {
       listRef.current.scrollTop = 0;
       setIsAtBottom(false);
+      setIsAtTop(true);
     }
   };
 
@@ -57,7 +60,7 @@ const Search = () => {
   };
 
   return (
-    <section className="grid max-w-[600px] min-w-[300px] h-full w-full space-y-4 pt-10">
+    <section className="grid max-w-[600px] min-w-[300px] min-h-full w-full space-y-4 pt-10">
       {/* search bar */}
       <div className="flex flex-row-reverse items-stretch font-mono text-lg text-secondary max-h-[44px] min-w-full">
         <Input
@@ -75,7 +78,11 @@ const Search = () => {
       <ul 
         ref={listRef}
         onScroll={handleScroll}
-        className={`pl-6 pb-4 space-y-2 overflow-y-scroll text-white max-h-[300px] min-w-full ${isAtBottom ? 'scroll-at-bottom' : ''}`}
+        className={clsx(
+          'pl-6 pb-4 space-y-2 overflow-y-scroll text-white max-h-[300px] min-w-full',
+          isAtBottom && 'scroll-at-bottom',
+          !isAtTop && 'scroll-not-at-top'
+        )}
       >
         {currMemberState.map((member, index) => {
           return (

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -94,6 +94,21 @@
     
     -webkit-mask: var(--mask); 
     mask: var(--mask);
+    -webkit-mask-size: 100% 100%;
+    mask-size: 100% 100%;
+    transition: -webkit-mask-size 0.3s ease, mask-size 0.3s ease;
+  }
+
+  ul.scroll-at-bottom {
+    --mask: linear-gradient(
+        to bottom, 
+        rgba(0,0,0,0) 0%,   /* Start fully transparent */
+        rgba(0,0,0,1) 0%,  /* Transition to fully opaque */
+        rgba(0,0,0,1) 100%  /* Stay opaque all the way to the bottom */
+    );
+    
+    -webkit-mask: var(--mask);
+    mask: var(--mask);
   }
 
   ::selection {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -84,31 +84,31 @@
 
 @layer utilities {
   ul {
-    --mask: linear-gradient(
-        to bottom, 
-        rgba(0,0,0,0) 0%,   /* Start fully transparent */
-        rgba(0,0,0,1) 0%,  /* Transition to fully opaque */
-        rgba(0,0,0,1) 70%,  /* Stay opaque */
-        rgba(0,0,0,0) 100%  /* End fully transparent */
-    );
-    
-    -webkit-mask: var(--mask); 
-    mask: var(--mask);
-    -webkit-mask-size: 100% 100%;
-    mask-size: 100% 100%;
-    transition: -webkit-mask-size 0.3s ease, mask-size 0.3s ease;
-  }
+    --fade-opacity-start: 0;
+    --fade-opacity-end: 1;
+    --fade-top: var(--fade-opacity-end); /* start with no top fade */
+    --fade-bottom: var(--fade-opacity-start); /* start with fade on bottom */
+    --fade-intensity: 15%; /* intensity of the gradient */
 
-  ul.scroll-at-bottom {
     --mask: linear-gradient(
-        to bottom, 
-        rgba(0,0,0,0) 0%,   /* Start fully transparent */
-        rgba(0,0,0,1) 0%,  /* Transition to fully opaque */
-        rgba(0,0,0,1) 100%  /* Stay opaque all the way to the bottom */
+      rgba(0,0,0,var(--fade-top)) 0%,
+      rgba(0,0,0,var(--fade-opacity-end)) var(--fade-intensity),
+      rgba(0,0,0,var(--fade-opacity-end)) calc(100% - var(--fade-intensity)),
+      rgba(0,0,0,var(--fade-bottom)) 100%
     );
-    
+
     -webkit-mask: var(--mask);
     mask: var(--mask);
+  }
+
+  /* add top fade when not at top */
+  ul.scroll-not-at-top {
+    --fade-top: var(--fade-opacity-start);
+  }
+  
+  /* remove bottom fade when at bottom */
+  ul.scroll-at-bottom {
+    --fade-bottom: var(--fade-opacity-end);
   }
 
   ::selection {


### PR DESCRIPTION
* Removed fade from the bottom of the list when scrolled all the way down to prevent the bottom entries being affected visually.
* Added a similar fade to the top of the list when scrolling down
* Reduced the fade from 30% to 15% for the top and bottom fade so there is maximum 30% of the list is affected by the fade instead of 60%

![ece_webring_pr-01](https://github.com/user-attachments/assets/7f498e1e-e77d-4d41-b755-c3414a509371)

---

~~Increased the height of the `Search` component to take up full height of its parent container.~~

Before:
![image](https://github.com/user-attachments/assets/5bfa0295-275c-4eb5-afe4-ef99bbf815ec)

~~After:~~
![image](https://github.com/user-attachments/assets/08a8f3bd-d0cd-4bcf-bbd4-0dcb16689625)

---

Tested on different browsers and on mobile screen, no visual bugs.